### PR TITLE
RDS Integration Failure

### DIFF
--- a/manifests/kustomize/base/argo/workflow-controller-configmap.yaml
+++ b/manifests/kustomize/base/argo/workflow-controller-configmap.yaml
@@ -13,7 +13,7 @@ data:
         s3: {
             bucket: $(kfp-artifact-bucket-name),
             keyPrefix: artifacts,
-            endpoint: minio-service.$(kfp-namespace):9000,
+            endpoint: s3.amazonaws.com,
             insecure: true,
             accessKeySecret: {
                 name: mlpipeline-minio-artifact,

--- a/manifests/kustomize/base/params-db-secret.env
+++ b/manifests/kustomize/base/params-db-secret.env
@@ -1,2 +1,2 @@
-username=root
-password=
+username=YOUR_RDS_USERNAME
+password=YOUR_RDS_PASSWORD

--- a/manifests/kustomize/base/params.env
+++ b/manifests/kustomize/base/params.env
@@ -1,12 +1,14 @@
 appName=pipeline
 appVersion=1.0.0
-dbHost=mysql
+dbHost=YOUR_AWS_RDS_ENDPOINT
 dbPort=3306
 mlmdDb=metadb
 cacheDb=cachedb
 pipelineDb=mlpipeline
-bucketName=mlpipeline
-
+bucketName=xyshow-standalone-kfp-data
+minioServiceHost=s3.amazonaws.com
+minioServiceRegion=us-west-2
+minioServiceSecure=true
 
 ## containerRuntimeExecutor: A workflow executor is a process
 ## that allows Argo to perform certain actions like monitoring pod logs,

--- a/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-apiserver-deployment.yaml
@@ -20,12 +20,27 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
         - name: OBJECTSTORECONFIG_SECURE
-          value: "false"
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: minioServiceSecure
         - name: OBJECTSTORECONFIG_BUCKETNAME
           valueFrom:
             configMapKeyRef:
               name: pipeline-install-config
               key: bucketName
+        - name: OBJECTSTORECONFIG_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: minioServiceHost
+        - name: OBJECTSTORECONFIG_REGION
+          valueFrom:
+            configMapKeyRef:
+              name: pipeline-install-config
+              key: minioServiceRegion
+        - name: OBJECTSTORECONFIG_PORT
+          value: ""
         - name: DBCONFIG_USER
           valueFrom:
             secretKeyRef:

--- a/manifests/kustomize/base/pipeline/ml-pipeline-ui-deployment.yaml
+++ b/manifests/kustomize/base/pipeline/ml-pipeline-ui-deployment.yaml
@@ -44,6 +44,16 @@ spec:
               secretKeyRef:
                 name: mlpipeline-minio-artifact
                 key: secretkey
+          - name: AWS_ACCESS_KEY_ID
+            valueFrom:
+              secretKeyRef:
+                name: mlpipeline-minio-artifact
+                key: accesskey
+          - name: AWS_SECRET_ACCESS_KEY
+            valueFrom:
+              secretKeyRef:
+                name: mlpipeline-minio-artifact
+                key: secretkey
           - name: ALLOW_CUSTOM_VISUALIZATIONS
             value: "true"
         readinessProbe:

--- a/manifests/kustomize/env/platform-agnostic/minio/minio-artifact-secret.env
+++ b/manifests/kustomize/env/platform-agnostic/minio/minio-artifact-secret.env
@@ -1,2 +1,2 @@
-accesskey=minio
-secretkey=minio123
+accesskey=YOUR_AWS_ACCESS_KEY
+secretkey=YOUR_AWS_SECRET_KEY


### PR DESCRIPTION
**Description of your changes:**
1) Test S3 and it works fine
2) Test RDS and all the installation is good. But when I tried to `create run from the pipeline`, below error surfaces:

```
Error occured while trying to proxy to: localhost:8080/apis/v1beta1/runs
```

Then I check logs of `ml-pipeline-apiserver` pod:
```
I0808 23:12:59.101409       6 interceptor.go:29] /api.RunService/CreateRun handler starting
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x138 pc=0x11be2d6]

goroutine 152 [running]:
github.com/kubeflow/pipelines/backend/src/common/util.(*Workflow).VerifyParameters(0xc0004de110, 0xc000c7e870, 0x0, 0xc000c7e870)
	backend/src/common/util/workflow.go:66 +0x96
	
github.com/kubeflow/pipelines/backend/src/apiserver/resource.(*ResourceManager).CreateRun(0xc000b3e000, 0xc000b3e8c0, 0xc000c7eb70, 0xc000ca01b0, 0x2)
	backend/src/apiserver/resource/resource_manager.go:326 +0x20e
	
github.com/kubeflow/pipelines/backend/src/apiserver/server.(*RunServer).CreateRun(0xc00000e030, 0x196e1e0, 0xc000c7eb70, 0xc000c7eba0, 0xc00000e030, 0x1, 0x1)
	backend/src/apiserver/server/run_server.go:43 +0xc5
github.com/kubeflow/pipelines/backend/api/go_client._RunService_CreateRun_Handler.func1(0x196e1e0, 0xc000c7eb70, 0x16b4d60, 0xc000c7eba0, 0x1, 0x0, 0xc000090380, 0x0)
	bazel-out/k8-opt/bin/backend/api/linux_amd64_stripped/go_client_go_proto%/github.com/kubeflow/pipelines/backend/api/go_client/run.pb.go:1277 +0x86
main.apiServerInterceptor(0x196e1e0, 0xc000c7eb70, 0x16b4d60, 0xc000c7eba0, 0xc0005d5b40, 0xc0005d5b60, 0x15c1f00, 0x25f3a90, 0x173b520, 0xc000340400)
	backend/src/apiserver/interceptor.go:30 +0xf4
github.com/kubeflow/pipelines/backend/api/go_client._RunService_CreateRun_Handler(0x16e7b80, 0xc00000e030, 0x196e1e0, 0xc000c7eb70, 0xc000c68500, 0x182d9b0, 0x0, 0x0, 0xc000ace000, 0x9e)
	bazel-out/k8-opt/bin/backend/api/linux_amd64_stripped/go_client_go_proto%/github.com/kubeflow/pipelines/backend/api/go_client/run.pb.go:1279 +0x158
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000122300, 0x197b2c0, 0xc000c63080, 0xc000340400, 0xc000b56270, 0x25650c0, 0x0, 0x0, 0x0)
	external/org_golang_google_grpc/server.go:966 +0x4a2
google.golang.org/grpc.(*Server).handleStream(0xc000122300, 0x197b2c0, 0xc000c63080, 0xc000340400, 0x0)
	external/org_golang_google_grpc/server.go:1245 +0xd61
google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc000cbdb50, 0xc000122300, 0x197b2c0, 0xc000c63080, 0xc000340400)
	external/org_golang_google_grpc/server.go:685 +0x9f
created by google.golang.org/grpc.(*Server).serveStreams.func1
	external/org_golang_google_grpc/server.go:683 +0xa1
```

Then I checked logs of `metadata-grpc-deployment` pod, it said `Server connection is built and start to listen`.

So I assume the RDS connection is okay, not sure how RDS integration effect `CreatRun`.

In a word:

1) ListPipeline / ListRun / ListExperiments / CreateExperiments is okay.
2) CreateRun failed.
